### PR TITLE
feat: Add configurable default location (WEATHER_DEFAULT_LOCATION)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,23 @@ WEATHER_UNITS=imperial
 #   WEATHER_TIME_FORMAT=24h
 
 # ============================================================================
+# DEFAULT LOCATION (v1.14.0)
+# ============================================================================
+# Optional fallback location used when a weather tool is called with no
+# location at all. An explicit location in the request always wins.
+# Responses that use the default disclose it in a "server default" header.
+#
+# Accepts any ONE of:
+#   - A free-text place name (geocoded once, then cached):
+#       WEATHER_DEFAULT_LOCATION=Christchurch, New Zealand
+#   - A saved location alias (see save_location):
+#       WEATHER_DEFAULT_LOCATION=home
+#   - Exact "lat,lon" coordinates:
+#       WEATHER_DEFAULT_LOCATION=-43.5321,172.6362
+#
+# WEATHER_DEFAULT_LOCATION=
+
+# ============================================================================
 # LIGHTNING DETECTION (v1.5.0)
 # ============================================================================
 # MQTT broker URL for Blitzortung lightning detection

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Configurable default location (`WEATHER_DEFAULT_LOCATION`)** - Optional server-wide fallback used when a location-based tool is called with no location at all, so clients whose users have a known home location can ask "what's the weather?" without passing coordinates every time. Accepts a saved location alias (including alternate names), a `"lat,lon"` coordinate pair, or a free-text place name (geocoded through the existing city-name cache, so it resolves at most once per process). An explicit `latitude`/`longitude`, `location_name`, or `city_name` in the call always takes precedence. Responses that used the fallback disclose it with a `**Location:** … — server default` header, and when a default is configured the tool schemas tell the model it may omit location parameters. Requested in [#46](https://github.com/weather-mcp/weather-mcp/issues/46). (`src/config/defaultLocation.ts`, `src/utils/locationResolver.ts`, `src/index.ts`)
+
 ## [1.13.0] - 2026-07-17
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -274,6 +274,12 @@ CACHE_MAX_SIZE=1000            # Max cache entries (100-10000, default: 1000)
 # API Configuration
 API_TIMEOUT_MS=30000           # API timeout in milliseconds (5000-120000, default: 30000)
 
+# Default Location
+WEATHER_DEFAULT_LOCATION=      # Optional fallback when a tool call has no location:
+                               # a saved alias, "lat,lon", or a free-text place name
+                               # (geocoded once, cached). Explicit locations always win;
+                               # responses disclose the fallback as "server default".
+
 # Lightning
 WEATHER_LIGHTNING_PREWARM=true # Subscribe saved locations at startup so lightning
                                # coverage accumulates before the first query (default: true).
@@ -560,7 +566,7 @@ npm audit             # No critical vulnerabilities
 - **New in v1.10.0:** Unit localization — imperial/metric (plus per-unit overrides and 12h/24h) via `WEATHER_UNITS` env or a per-call `units` parameter on forecast/current/historical tools
 - **New in v1.9.0:** `city_name` parameter for `get_forecast` — request a forecast by free-text place name (geocoded on demand, with caching)
 - **Security Rating:** A- (Excellent, 93/100)
-- **Test Coverage:** 1,332 tests, 100% pass rate
+- **Test Coverage:** 1,342 tests, 100% pass rate
 - **Code Quality:** A+ (Excellent, 97.5/100)
 
 ## Useful References

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![npm version](https://badge.fury.io/js/@dangahagan%2Fweather-mcp.svg)](https://www.npmjs.com/package/@dangahagan/weather-mcp)
 [![MCP Registry](https://img.shields.io/badge/MCP-Registry-blue)](https://registry.modelcontextprotocol.io/v0/servers?search=io.github.dgahagan/weather-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Tests](https://img.shields.io/badge/tests-1%2C332%20passing-brightgreen)](./docs/testing/TEST_SUITE_README.md)
+[![Tests](https://img.shields.io/badge/tests-1%2C342%20passing-brightgreen)](./docs/testing/TEST_SUITE_README.md)
 [![Node](https://img.shields.io/badge/node-%3E%3D18-339933?logo=node.js&logoColor=white)](https://nodejs.org)
 
 **Give your AI assistant real weather data — 17 tools, zero API keys, zero signup, zero cost.**
@@ -45,7 +45,7 @@ Choose this one if you want:
 
 - **Genuinely free** — every data source is a free public API. No trial that expires, no credit card, no rate-limited "free tier" bait.
 - **No API keys** — install to first forecast in under a minute. Nothing to configure, nothing to leak into a repo.
-- **Fully open source** — MIT licensed, readable TypeScript, 1,332 tests. Audit it, fork it, fix it.
+- **Fully open source** — MIT licensed, readable TypeScript, 1,342 tests. Audit it, fork it, fix it.
 - **Privacy-respecting** — your queries go directly from your machine to public weather APIs. No middleman server, no telemetry.
 - **Breadth** — 17 tools covering weather, safety hazards (lightning, floods, wildfires), marine conditions, air quality, and historical data back to 1940. Most weather MCPs stop at forecasts.
 
@@ -223,11 +223,24 @@ Or per call — the AI can honor "in Celsius" on the fly:
 
 Supported on `get_forecast`, `get_current_conditions`, and `get_historical_weather`. Wind accepts `mph`/`kmh`/`ms`/`kn`; pressure `inHg`/`hPa`. Domain-specialized readings (fire-weather heights, river gauge stage, and the marine tool's dual-unit wave output) keep their conventional units.
 
+### Default Location
+
+Set `WEATHER_DEFAULT_LOCATION` and weather tools work with no location argument at all — useful when your assistant already knows where you are, so "what's the weather?" just works:
+
+```bash
+WEATHER_DEFAULT_LOCATION="Christchurch, New Zealand"   # free-text (geocoded once, then cached)
+WEATHER_DEFAULT_LOCATION="home"                        # a saved location alias
+WEATHER_DEFAULT_LOCATION="-43.5321,172.6362"           # exact coordinates
+```
+
+An explicit location in the request always wins — the default only applies when no coordinates, `location_name`, or `city_name` are provided. Responses using the default disclose it with a `**Location:** … — server default` header.
+
 ### Other settings
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
 | `ENABLED_TOOLS` | `basic` | Tool preset or list (see above) |
+| `WEATHER_DEFAULT_LOCATION` | — | Fallback location when a tool call has none: a saved alias, `"lat,lon"`, or a free-text place name (see above) |
 | `WEATHER_UNITS` | `imperial` | Default unit system: `imperial` or `metric` |
 | `WEATHER_TEMPERATURE_UNIT` … | — | Per-unit overrides: `_TEMPERATURE_`(F/C), `_WIND_SPEED_`(mph/kmh/ms/kn), `_PRECIPITATION_`(inch/mm), `_PRESSURE_`(inHg/hPa), `_DISTANCE_`(mi/km), `_TIME_FORMAT`(12h/24h) |
 | `CACHE_ENABLED` | `true` | Enable/disable response caching |
@@ -262,7 +275,7 @@ Being honest about what free public data can and can't do:
 ```bash
 npm run build          # Compile TypeScript
 npm run dev            # Run in development mode
-npm test               # Run all 1,332 tests (~2 seconds)
+npm test               # Run all 1,342 tests (~2 seconds)
 npm run test:coverage  # Coverage report
 npm run audit          # Dependency vulnerability scan
 ```

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -4,7 +4,7 @@ Complete reference for all 17 MCP tools provided by the Weather MCP Server.
 
 > **Note on tool presets:** By default the server exposes the `basic` preset (6 tools, led by `get_weather_summary`). Set `ENABLED_TOOLS=all` to enable everything. See [Tool Selection](../README.md#tool-selection) in the README.
 
-> **Common parameters (all location-based tools):** Every weather tool accepts the location in one of three ways — `latitude`+`longitude`, a saved `location_name` (e.g. `"home"`), or a free-text `city_name` (e.g. `"Bend, Oregon"`, geocoded on demand). Precedence: coordinates > `location_name` > `city_name`. When a name is used, the response echoes the resolved place in a `**Location:**` header. The high-volume tools (`get_forecast`, `get_alerts`, `get_weather_imagery`, `get_river_conditions`, `get_wildfire_info`, `get_lightning_activity`) also accept `detail`: `summary` | `standard` (default) | `full`.
+> **Common parameters (all location-based tools):** Every weather tool accepts the location in one of three ways — `latitude`+`longitude`, a saved `location_name` (e.g. `"home"`), or a free-text `city_name` (e.g. `"Bend, Oregon"`, geocoded on demand). Precedence: coordinates > `location_name` > `city_name`. When a name is used, the response echoes the resolved place in a `**Location:**` header. If the server sets `WEATHER_DEFAULT_LOCATION`, all location parameters may be omitted — the configured default is used and disclosed as `— server default` in that header. The high-volume tools (`get_forecast`, `get_alerts`, `get_weather_imagery`, `get_river_conditions`, `get_wildfire_info`, `get_lightning_activity`) also accept `detail`: `summary` | `standard` (default) | `full`.
 
 ## Contents
 

--- a/src/config/defaultLocation.ts
+++ b/src/config/defaultLocation.ts
@@ -1,0 +1,27 @@
+/**
+ * Default location configuration.
+ *
+ * WEATHER_DEFAULT_LOCATION — optional server-wide fallback location, used when
+ * a location-based tool is called with no location at all. Accepts any of:
+ *
+ *   - A saved location alias:      WEATHER_DEFAULT_LOCATION=home
+ *   - A "lat,lon" coordinate pair: WEATHER_DEFAULT_LOCATION=-43.5321,172.6362
+ *   - A free-text place name:      WEATHER_DEFAULT_LOCATION=Christchurch, New Zealand
+ *
+ * An explicit location in the tool call always takes precedence — the default
+ * only applies when latitude/longitude, location_name, and city_name are all
+ * absent. See resolveLocationAsync in src/utils/locationResolver.ts.
+ */
+
+/**
+ * Return the configured default location string, or undefined when unset or
+ * blank. Read from the environment on each call (a hash lookup) rather than
+ * cached at module load, so tests and hosts that adjust the environment
+ * observe the change without re-importing the module.
+ */
+export function getDefaultLocation(): string | undefined {
+  const raw = process.env.WEATHER_DEFAULT_LOCATION;
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import { LocationStore } from './services/locationStore.js';
 import { blitzortungService } from './services/blitzortung.js';
 import { CacheConfig } from './config/cache.js';
 import { toolConfig } from './config/tools.js';
+import { getDefaultLocation } from './config/defaultLocation.js';
 import { logger } from './utils/logger.js';
 import { formatErrorForUser } from './errors/ApiError.js';
 import { handleGetForecast } from './handlers/forecastHandler.js';
@@ -204,12 +205,19 @@ const UNIT_SCHEMA_PROPERTIES = {
  * the AI can provide a location in ONE of three consistent ways: coordinates,
  * a saved location name, or a free-text city name (geocoded on demand). Tools
  * using this fragment must declare `required: []` — resolveLocationAsync enforces
- * that at least one usable form is present at call time.
+ * that at least one usable form is present at call time (falling back to
+ * WEATHER_DEFAULT_LOCATION when the operator has configured one; the hint below
+ * is only added to the schema in that case, so models don't omit locations on
+ * servers with no default).
  */
+const DEFAULT_LOCATION_HINT = getDefaultLocation()
+  ? ` If the user does not specify a location, omit all location parameters — the server's configured default location ("${getDefaultLocation()}") is used.`
+  : '';
+
 const LOCATION_SCHEMA_PROPERTIES = {
   latitude: {
     type: 'number' as const,
-    description: 'Latitude of the location (-90 to 90). Not required if location_name or city_name is provided.',
+    description: `Latitude of the location (-90 to 90). Not required if location_name or city_name is provided.${DEFAULT_LOCATION_HINT}`,
     minimum: -90,
     maximum: 90
   },

--- a/src/utils/locationResolver.ts
+++ b/src/utils/locationResolver.ts
@@ -7,6 +7,7 @@ import { GeocodingService } from '../services/geocoding.js';
 import { validateLatitude, validateLongitude } from './validation.js';
 import { Cache } from './cache.js';
 import { CacheConfig } from '../config/cache.js';
+import { getDefaultLocation } from '../config/defaultLocation.js';
 
 export interface LocationInput {
   latitude?: number;
@@ -18,7 +19,7 @@ export interface LocationInput {
 export interface ResolvedLocation {
   latitude: number;
   longitude: number;
-  source: 'coordinates' | 'saved_location' | 'geocoded';
+  source: 'coordinates' | 'saved_location' | 'geocoded' | 'default';
   location_name?: string;
 }
 
@@ -34,11 +35,19 @@ export interface ResolvedLocation {
  * @returns Markdown line (with trailing blank line) or '' for coordinate input
  */
 export function formatLocationLine(resolved: ResolvedLocation): string {
+  const coords = `${resolved.latitude.toFixed(4)}, ${resolved.longitude.toFixed(4)}`;
+
+  // A server-default location is always disclosed — the caller supplied no
+  // location at all, so the reader must be able to see what was assumed.
+  if (resolved.source === 'default') {
+    const label = resolved.location_name ? `${resolved.location_name} (${coords})` : coords;
+    return `**Location:** ${label} — server default\n\n`;
+  }
+
   if (resolved.source === 'coordinates' || !resolved.location_name) {
     return '';
   }
 
-  const coords = `${resolved.latitude.toFixed(4)}, ${resolved.longitude.toFixed(4)}`;
   return `**Location:** ${resolved.location_name} (${coords})\n\n`;
 }
 
@@ -181,15 +190,17 @@ export function resolveLocation(
  * Resolve location coordinates from direct coordinates, a saved location name,
  * or a free-text city name that is geocoded on demand.
  *
- * Resolution precedence: coordinates > location_name (saved) > city_name (geocoded).
- * Geocoded city lookups are cached (see cityGeocodeCache) so repeated requests for
- * the same place do not re-hit the geocoding providers.
+ * Resolution precedence: coordinates > location_name (saved) > city_name (geocoded)
+ * > server default (WEATHER_DEFAULT_LOCATION, when configured). Geocoded city
+ * lookups are cached (see cityGeocodeCache) so repeated requests for the same
+ * place do not re-hit the geocoding providers.
  *
  * @param args - Arguments containing coordinates, a saved location_name, or a city_name
  * @param locationStore - Location store instance (for saved locations)
  * @param geocodingService - Geocoding service (for city_name lookups)
  * @returns Resolved coordinates and metadata
- * @throws Error if nothing usable is provided, validation fails, or geocoding finds no match
+ * @throws Error if nothing usable is provided (and no default is configured),
+ *   validation fails, or geocoding finds no match
  */
 export async function resolveLocationAsync(
   args: LocationInput,
@@ -267,6 +278,12 @@ export async function resolveLocationAsync(
     };
   }
 
+  // 4. Nothing provided -> configured server default, if any
+  const defaultLocation = getDefaultLocation();
+  if (defaultLocation) {
+    return resolveDefaultLocation(defaultLocation, locationStore, geocodingService);
+  }
+
   // Nothing usable provided
   throw new Error(
     'Provide one of: coordinates (latitude + longitude), a saved location_name, or a city_name.\n\n' +
@@ -274,6 +291,62 @@ export async function resolveLocationAsync(
     '  - Using coordinates: latitude=47.6062, longitude=-122.3321\n' +
     '  - Using saved location: location_name="home"\n' +
     '  - Using a city name: city_name="Paris, France"\n\n' +
-    'Use save_location to save frequently used locations.'
+    'Use save_location to save frequently used locations. The server operator can ' +
+    'also set the WEATHER_DEFAULT_LOCATION environment variable to supply a ' +
+    'fallback location for calls like this one.'
   );
+}
+
+/**
+ * Resolve the WEATHER_DEFAULT_LOCATION value to coordinates.
+ *
+ * The value may be a "lat,lon" coordinate pair, a saved location alias (or
+ * alternate name), or a free-text place name — tried in that order. Free-text
+ * lookups reuse the city geocode path, so they hit the same cache and only
+ * geocode once per process. Whatever matches is reported with
+ * source: 'default' so output always discloses that the location was assumed.
+ *
+ * @throws Error naming WEATHER_DEFAULT_LOCATION when the value cannot be resolved
+ */
+async function resolveDefaultLocation(
+  raw: string,
+  locationStore: LocationStore,
+  geocodingService: GeocodingService
+): Promise<ResolvedLocation> {
+  // "lat,lon" coordinate pair
+  const coordMatch = raw.match(/^\s*(-?\d+(?:\.\d+)?)\s*,\s*(-?\d+(?:\.\d+)?)\s*$/);
+  if (coordMatch) {
+    const latitude = Number(coordMatch[1]);
+    const longitude = Number(coordMatch[2]);
+    try {
+      validateLatitude(latitude);
+      validateLongitude(longitude);
+    } catch (error) {
+      throw new Error(
+        `Invalid WEATHER_DEFAULT_LOCATION coordinates "${raw}": ` +
+        `${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+    return { latitude, longitude, source: 'default' };
+  }
+
+  // Saved location alias (including alternate names)
+  try {
+    const saved = resolveLocation({ location_name: raw }, locationStore);
+    return { ...saved, source: 'default' };
+  } catch {
+    // Not a saved alias — treat it as a free-text place name below.
+  }
+
+  // Free-text place name -> geocode (shares the city_name cache)
+  try {
+    const geocoded = await resolveLocationAsync({ city_name: raw }, locationStore, geocodingService);
+    return { ...geocoded, source: 'default' };
+  } catch (error) {
+    throw new Error(
+      `Could not resolve WEATHER_DEFAULT_LOCATION="${raw}" — it is not a saved ` +
+      `location alias, a "lat,lon" pair, or a geocodable place name.\n\n` +
+      `${error instanceof Error ? error.message : String(error)}`
+    );
+  }
 }

--- a/tests/unit/locationResolver.test.ts
+++ b/tests/unit/locationResolver.test.ts
@@ -5,7 +5,7 @@
  * coordinates, a saved location name, or a free-text city name (geocoded).
  */
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import {
   resolveLocationAsync,
   clearCityGeocodeCache,
@@ -232,6 +232,137 @@ describe('resolveLocationAsync', () => {
       );
     });
   });
+
+  describe('default location fallback (WEATHER_DEFAULT_LOCATION)', () => {
+    const ENV_KEY = 'WEATHER_DEFAULT_LOCATION';
+    let savedEnv: string | undefined;
+
+    beforeEach(() => {
+      savedEnv = process.env[ENV_KEY];
+      delete process.env[ENV_KEY];
+    });
+
+    afterEach(() => {
+      if (savedEnv === undefined) {
+        delete process.env[ENV_KEY];
+      } else {
+        process.env[ENV_KEY] = savedEnv;
+      }
+    });
+
+    it('resolves a "lat,lon" coordinate pair default', async () => {
+      process.env[ENV_KEY] = '-43.5321, 172.6362';
+      const store = makeLocationStore();
+      const { service, geocode } = makeGeocodingService([]);
+
+      const resolved = await resolveLocationAsync({}, store, service);
+
+      expect(resolved).toEqual({
+        latitude: -43.5321,
+        longitude: 172.6362,
+        source: 'default',
+      });
+      expect(geocode).not.toHaveBeenCalled();
+    });
+
+    it('resolves a saved location alias default', async () => {
+      process.env[ENV_KEY] = 'home';
+      const store = makeLocationStore({ home: makeSavedLocation() });
+      const { service, geocode } = makeGeocodingService([]);
+
+      const resolved = await resolveLocationAsync({}, store, service);
+
+      expect(resolved).toEqual({
+        latitude: 47.6062,
+        longitude: -122.3321,
+        source: 'default',
+        location_name: 'home',
+      });
+      expect(geocode).not.toHaveBeenCalled();
+    });
+
+    it('resolves a saved location alternate-name default', async () => {
+      process.env[ENV_KEY] = 'my house';
+      const store = makeLocationStore({
+        home: makeSavedLocation({ alternateNames: ['my house'] } as Partial<SavedLocation>),
+      });
+      const { service, geocode } = makeGeocodingService([]);
+
+      const resolved = await resolveLocationAsync({}, store, service);
+
+      expect(resolved.source).toBe('default');
+      expect(resolved.location_name).toBe('home');
+      expect(geocode).not.toHaveBeenCalled();
+    });
+
+    it('geocodes a free-text place name default', async () => {
+      process.env[ENV_KEY] = 'Christchurch, New Zealand';
+      const store = makeLocationStore();
+      const { service, geocode } = makeGeocodingService([
+        makeGeocodingResult({
+          display_name: 'Christchurch, Canterbury, New Zealand',
+          latitude: -43.531,
+          longitude: 172.6365,
+        }),
+      ]);
+
+      const resolved = await resolveLocationAsync({}, store, service);
+
+      expect(resolved).toEqual({
+        latitude: -43.531,
+        longitude: 172.6365,
+        source: 'default',
+        location_name: 'Christchurch, Canterbury, New Zealand',
+      });
+      expect(geocode).toHaveBeenCalledWith('Christchurch, New Zealand', 1);
+    });
+
+    it('never applies the default when an explicit location is provided', async () => {
+      process.env[ENV_KEY] = 'Christchurch, New Zealand';
+      const store = makeLocationStore({ home: makeSavedLocation() });
+      const { service, geocode } = makeGeocodingService([makeGeocodingResult()]);
+
+      const byCoords = await resolveLocationAsync({ latitude: 10, longitude: 20 }, store, service);
+      const bySaved = await resolveLocationAsync({ location_name: 'home' }, store, service);
+      const byCity = await resolveLocationAsync({ city_name: 'Paris' }, store, service);
+
+      expect(byCoords.source).toBe('coordinates');
+      expect(bySaved.source).toBe('saved_location');
+      expect(byCity.source).toBe('geocoded');
+      expect(geocode).toHaveBeenCalledTimes(1); // only the explicit city_name lookup
+      expect(geocode).toHaveBeenCalledWith('Paris', 1);
+    });
+
+    it('throws a WEATHER_DEFAULT_LOCATION-specific error for out-of-range coordinates', async () => {
+      process.env[ENV_KEY] = '999, 0';
+      const store = makeLocationStore();
+      const { service } = makeGeocodingService([]);
+
+      await expect(resolveLocationAsync({}, store, service)).rejects.toThrow(
+        /WEATHER_DEFAULT_LOCATION/
+      );
+    });
+
+    it('throws a WEATHER_DEFAULT_LOCATION-specific error when nothing matches', async () => {
+      process.env[ENV_KEY] = 'Nonexistentville';
+      const store = makeLocationStore();
+      const { service } = makeGeocodingService([]);
+
+      await expect(resolveLocationAsync({}, store, service)).rejects.toThrow(
+        /WEATHER_DEFAULT_LOCATION/
+      );
+    });
+
+    it('ignores a blank default and keeps the standard no-input error', async () => {
+      process.env[ENV_KEY] = '   ';
+      const store = makeLocationStore();
+      const { service } = makeGeocodingService([]);
+
+      await expect(resolveLocationAsync({}, store, service)).rejects.toThrow(
+        /Provide one of/i
+      );
+    });
+  });
 });
 
 describe('formatLocationLine', () => {
@@ -263,6 +394,29 @@ describe('formatLocationLine', () => {
     };
     expect(formatLocationLine(resolved)).toContain('Paris, Île-de-France, France');
     expect(formatLocationLine(resolved)).toContain('48.8566, 2.3522');
+  });
+
+  it('discloses a named server default with a "server default" marker', () => {
+    const resolved: ResolvedLocation = {
+      latitude: -43.531,
+      longitude: 172.6365,
+      source: 'default',
+      location_name: 'Christchurch, Canterbury, New Zealand',
+    };
+    expect(formatLocationLine(resolved)).toBe(
+      '**Location:** Christchurch, Canterbury, New Zealand (-43.5310, 172.6365) — server default\n\n'
+    );
+  });
+
+  it('discloses a coordinate-only server default', () => {
+    const resolved: ResolvedLocation = {
+      latitude: -43.5321,
+      longitude: 172.6362,
+      source: 'default',
+    };
+    expect(formatLocationLine(resolved)).toBe(
+      '**Location:** -43.5321, 172.6362 — server default\n\n'
+    );
   });
 });
 


### PR DESCRIPTION
Closes #46.

Adds an optional server-wide fallback location, used when a location-based tool is called with no location at all — so MCP clients whose users have one obvious location can ask *"what's the weather?"* with zero parameters.

## Usage

```bash
WEATHER_DEFAULT_LOCATION="Christchurch, New Zealand"   # free-text (geocoded once, then cached)
WEATHER_DEFAULT_LOCATION="home"                        # a saved location alias
WEATHER_DEFAULT_LOCATION="-43.5321,172.6362"           # exact coordinates
```

## Behavior

- **Explicit input always wins.** The default only applies when `latitude`/`longitude`, `location_name`, and `city_name` are all absent — exactly the precedence the issue requested.
- **Three accepted forms**, tried in order: a `"lat,lon"` coordinate pair, a saved location alias (including alternate names), then a free-text place name geocoded through the existing city-name cache (at most one geocode per process).
- **Disclosed, never silent.** Responses that used the fallback carry a `**Location:** Christchurch, Canterbury, New Zealand (-43.5310, 172.6365) — server default` header.
- **Schema-aware.** When a default is configured, the shared location schema tells the model it may omit location parameters; unconfigured servers keep their schemas unchanged so models don't start omitting locations where there is no fallback.
- **Clear failures.** An unresolvable or out-of-range default produces an error that names `WEATHER_DEFAULT_LOCATION`.

## Implementation

- `src/config/defaultLocation.ts` — env read (per call, so tests/hosts observe changes)
- `src/utils/locationResolver.ts` — fallback step in `resolveLocationAsync`, new `'default'` source, disclosure in `formatLocationLine`; covers all 11 location-based tools including `get_weather_summary`
- `src/index.ts` — conditional schema hint
- Docs: README, `.env.example`, `docs/TOOLS.md`, CHANGELOG, CLAUDE.md

## Testing

- 10 new unit tests (coordinate pair, saved alias, alternate name, geocoded free text, precedence, error paths, blank value, header formats)
- Full suite: **1,342 tests passing**, `tsc` clean, doc-consistency check green

🤖 Generated with [Claude Code](https://claude.com/claude-code)