### PR TITLE
docs: Exercise the v1.20.0 fire features in examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@ Each file in this folder is a realistic session: a user prompt, the answer **Cla
 | [A day on the water](./boating-and-marine.md) | Sydney | Marine forecast (waves, swell, currents), real-time lightning detection, metric units |
 | [Traveling abroad](./international-travel.md) | Paris | Real airport station observations anywhere on earth (`source: "metar"`), European pollen levels |
 | [River levels, two ways](./river-and-flood.md) | Memphis + Manaus | US flood-stage gauges vs. global modeled river discharge — same tool, honest about the difference |
-| [Wildfire season check-in](./wildfire-awareness.md) | Denver | Active fires with containment & distance, smoke via US AQI |
+| [Wildfire season check-in](./wildfire-awareness.md) | Denver + Athens | US named incidents (containment, distance) vs. global satellite hotspots — plus NOAA's published fire indices vs. a server-computed Fosberg index, each labeled for what it is |
 | [Reaching into the past](./historical-climate.md) | Berlin 1945 + Chicago | Historical archive back to 1940, climate normals & US record high/low for the date |
 | [Saving your places](./saved-locations-workflow.md) | Lake Tahoe | Save a location once ("cabin"), then ask about it by name |
 
@@ -24,7 +24,7 @@ All 17 tools appear across these examples:
 | Tool | Shown in |
 |---|---|
 | `get_forecast` | [trip planning](./weekend-trip-planning.md), [saved locations](./saved-locations-workflow.md) |
-| `get_current_conditions` | [international travel](./international-travel.md) (METAR), [historical & climate](./historical-climate.md) (normals + records) |
+| `get_current_conditions` | [international travel](./international-travel.md) (METAR), [historical & climate](./historical-climate.md) (normals + records), [wildfire](./wildfire-awareness.md) (fire weather, both paths) |
 | `get_alerts` | [severe weather](./severe-weather-day.md) |
 | `get_historical_weather` | [historical & climate](./historical-climate.md) |
 | `get_weather_summary` | [severe weather](./severe-weather-day.md) |
@@ -35,7 +35,7 @@ All 17 tools appear across these examples:
 | `get_weather_imagery` | [trip planning](./weekend-trip-planning.md) (with snapshot), [severe weather](./severe-weather-day.md) |
 | `get_lightning_activity` | [boating](./boating-and-marine.md) |
 | `get_river_conditions` | [rivers & flood](./river-and-flood.md) (both US and global paths) |
-| `get_wildfire_info` | [wildfire](./wildfire-awareness.md) |
+| `get_wildfire_info` | [wildfire](./wildfire-awareness.md) (both the NIFC and FIRMS paths) |
 | `save_location`, `list_saved_locations`, `get_saved_location`, `remove_saved_location` | [saved locations](./saved-locations-workflow.md) |
 
 ## Bonus: is everything up?

--- a/examples/wildfire-awareness.md
+++ b/examples/wildfire-awareness.md
@@ -1,4 +1,10 @@
-# Wildfire season check-in — Denver
+# Wildfire season check-in — Denver & Athens
+
+Fire season is a global question, but the *data* is not. In the US, an
+interagency system tracks named incidents with acreage and containment.
+Almost nowhere else does. This example asks the same two questions on both
+sides of that line — and the server is explicit about which kind of answer
+you're getting.
 
 > **You:** Are there any wildfires burning near Denver? Should I be worried about smoke for my run?
 
@@ -10,7 +16,7 @@ There are **8 active fires within 300 km of Denver, but none close enough to thr
 The ones worth knowing about:
 
 - **Willow** — the nearest, 88 miles away near Leadville: 7,196 acres, 67% contained.
-- **Aspen Acres** — the big one, 110 miles south near Beulah: 102,003 acres, 72% contained after 45 days.
+- **Aspen Acres** — the big one, 110 miles south near Beulah: 102,003 acres, 72% contained after 46 days.
 - Two others (Fishhook, Fuhr Gulch) are already **100% contained** — the server excludes fully contained fires from its danger assessment rather than letting them inflate it.
 
 For Denver itself the practical question is smoke, not flame — let's check the air quality next.
@@ -112,7 +118,7 @@ get_wildfire_info({
 **Size:** 603 acres (244 hectares)
 **Containment:** 76% ████████░░
 **Discovery Date:** 8/6/2026
-**Days Active:** 7
+**Days Active:** 8
 
 ---
 
@@ -138,9 +144,9 @@ get_wildfire_info({
 **And for smoke / air quality** (using `get_air_quality`):
 
 <!-- answer-2 -->
-**Your run is fine.** US AQI is **51 — barely into "Moderate"** — and the smoke signal specifically, PM2.5, is low at 8.8 μg/m³, so the distant fires aren't putting meaningful smoke at street level in Denver right now. Only unusually sensitive people are advised to trim prolonged outdoor exertion.
+**Your run is fine.** US AQI is **59 — mid-"Moderate"** — and the smoke signal specifically, PM2.5, is low at 7.3 μg/m³, so the distant fires aren't putting meaningful smoke at street level in Denver right now. Only unusually sensitive people are advised to trim prolonged outdoor exertion.
 
-One thing the run *does* need: sunscreen. UV index is 5 (Moderate) this afternoon at Denver's elevation.
+One thing the run *does* need: sunscreen. UV index is 5.7 (Moderate) this afternoon at Denver's elevation — and the server notes it would be 8.9 under clear sky, so don't let the cloud cover fool you.
 <!-- /answer-2 -->
 
 <!-- capture:air-quality -->
@@ -165,7 +171,7 @@ get_air_quality({
 **Timezone:** America/Denver
 **Elevation:** 1599m
 
-**Observation Time:** 8/14/2026, 12:00:00 PM
+**Observation Time:** 8/14/2026, 2:00:00 PM
 
 ## 🟡 US Air Quality Index: 59
 
@@ -177,22 +183,24 @@ Air quality is acceptable; however, unusually sensitive people may experience mi
 
 ⚠️ **Caution:** Unusually sensitive people should consider reducing prolonged outdoor exertion.
 
-## 🔴 UV Index: 9.2
+## 🟡 UV Index: 5.7
 
-**Level:** Very High
-**Description:** Extra protection required
-**Recommendation:** Minimize sun exposure 10am-4pm. Apply SPF 30+ sunscreen every 2 hours. Wear protective clothing and sunglasses.
+**Level:** Moderate
+**Description:** Protection recommended
+**Recommendation:** Wear sunscreen, hat, and sunglasses. Seek shade during midday hours.
+
+*Note: UV index under clear sky would be 8.9*
 
 ## Pollutant Concentrations
 
-**PM2.5 (Fine Particulate Matter):** 9.6 μg/m³
-**PM10 (Coarse Particulate Matter):** 10 μg/m³
-**Ozone (O₃):** 136 μg/m³
-**Nitrogen Dioxide (NO₂):** 3.3 μg/m³
-**Sulfur Dioxide (SO₂):** 1.0 μg/m³
-**Carbon Monoxide (CO):** 162 μg/m³
+**PM2.5 (Fine Particulate Matter):** 7.3 μg/m³
+**PM10 (Coarse Particulate Matter):** 7.9 μg/m³
+**Ozone (O₃):** 137 μg/m³
+**Nitrogen Dioxide (NO₂):** 1.9 μg/m³
+**Sulfur Dioxide (SO₂):** 0.70 μg/m³
+**Carbon Monoxide (CO):** 136 μg/m³
 **Ammonia (NH₃):** N/A
-**Aerosol Optical Depth:** 0.120 (atmospheric haze indicator)
+**Aerosol Optical Depth:** 0.160 (atmospheric haze indicator)
 
 *European AQI: 61 (Poor)*
 ````
@@ -200,9 +208,255 @@ Air quality is acceptable; however, unusually sensitive people may experience mi
 </details>
 <!-- /capture:air-quality -->
 
+**And the fire-weather side of it** (using `get_current_conditions` with `include_fire_weather`):
+
+<!-- answer-3 -->
+**Nothing to worry about today — it's actively raining at the reporting station.** NOAA rates the seasonal fire risk **Moderate** and explicitly says conditions don't meet the thresholds that trigger its danger indices, so Haines, Grassland Fire Danger, and Red Flag Threat simply aren't being calculated right now.
+
+What it *does* give you is the smoke-dispersion picture: a **205 ft mixing height (very poor dispersion)** with a 7 mph transport wind. That combination is worth knowing — if something did ignite, the smoke would sit low rather than lift away.
+
+Note where these numbers come from: NOAA **publishes** fire-weather indices for US points, so on this path the server reports them rather than deriving anything.
+<!-- /answer-3 -->
+
+<!-- capture:denver-fire-weather -->
+<details>
+<summary>🔍 Tool call & raw server output — <code>get_current_conditions</code></summary>
+
+**Call:**
+
+```js
+get_current_conditions({
+  latitude: 39.7392,
+  longitude: -104.9903,
+  include_fire_weather: true
+})
+```
+
+**The server returned** (verbatim — this is exactly what the MCP client receives):
+
+````markdown
+# Current Weather Conditions
+
+**Station:** https://api.weather.gov/stations/KBJC
+**Time:** Aug 14, 2026, 1:47 PM (36 minutes ago)
+
+**Conditions:**  Rain
+**Temperature:** 86°F
+**Wind:** 7 mph from 20°
+**Pressure:** 30.15 inHg
+**Visibility:** 10.0 miles
+**Cloud Cover:** Scattered clouds at 10007ft
+
+## Fire Weather
+
+🟡 **Seasonal Fire Risk:** Moderate
+Current conditions do not meet thresholds for fire weather concerns. Fire danger indices are calculated during periods of low humidity, high temperatures, and strong winds.
+
+**Atmospheric Monitoring:**
+**Mixing Height:** 205 ft (very poor dispersion)
+**Transport Wind:** 7 mph (moderate smoke transport)
+
+*Fire danger indices (Haines Index, Grassland Fire Danger, Red Flag Threat) are calculated during elevated fire risk periods, typically during dry seasons or when Red Flag conditions are possible.*
+
+---
+*Data source: NOAA National Weather Service*
+````
+
+</details>
+<!-- /capture:denver-fire-weather -->
+
 ---
 
-**Features shown:** `get_wildfire_info` — active fires within a radius (NIFC), containment, distance, safety assessment tier · `get_air_quality` on the US path — US AQI scale, pollutant breakdown (PM2.5 is the smoke signal), UV index, health recommendations.
+## The same two questions, outside the US
+
+> **You:** I'm in Athens next week and it's peak fire season. Same check — anything burning, and how dangerous are the conditions?
+
+**Claude Code answered** (using `get_wildfire_info`):
+
+<!-- answer-4 -->
+**Yes — 11 satellite heat detections in the last 3 days, in 8 clusters within 200 km**, and the nearest is close enough to put this at **HIGH ALERT**: 21.7 km WNW of the city center.
+
+But read this differently from the Denver answer, because it *is* different data:
+
+- These are **hotspots, not incidents.** There are no fire names, no acreage, no containment percentages — because no agency is publishing them here. What a satellite sees is heat.
+- Some of these may not be wildfires at all. The server says so up front: detections can be industrial heat sources, gas flares, or agricultural burns. The 21.7 km cluster is a single low-power hotspot (5.0 MW) last seen **2 days ago**, which reads more like a burn scar or a one-off than an advancing fire.
+- The liveliest signal is actually **Cluster 4** — two hotspots, 6.4 MW peak, and only **8.4 hours old** — but it's 127 km away near Lamia.
+
+So: worth watching, not worth panicking. And critically, if this had come back empty it still wouldn't have meant "no fires" — cloud cover hides fires from satellites, and the server refuses to print an all-clear it can't back up.
+<!-- /answer-4 -->
+
+<!-- capture:athens-hotspots -->
+<details>
+<summary>🔍 Tool call & raw server output — <code>get_wildfire_info</code></summary>
+
+**Call:**
+
+```js
+get_wildfire_info({
+  latitude: 37.9838,
+  longitude: 23.7275,
+  radius: 200,
+  day_range: 3
+})
+```
+
+**The server returned** (verbatim — this is exactly what the MCP client receives):
+
+````markdown
+# Wildfire Information Report
+
+**Location:** 37.9838, 23.7275
+**Search Radius:** 200 km (124.3 miles)
+**Source:** NASA FIRMS satellite fire detections (VIIRS, near real-time)
+
+⚠️ Satellite heat detections — not managed incident data. No fire names, sizes, or containment are available; detections may include industrial heat sources, gas flares, or agricultural burns.
+
+🔥 **11 satellite fire detections in the last 3 days, grouped into 8 clusters within 200 km**
+
+## Detection Cluster 1
+
+**Detections:** 1 hotspot (1 day / 0 night)
+**Distance:** 21.7 km (13.5 mi) WNW
+**Center:** 38.0279, 23.4857
+**Peak intensity:** 5.0 MW (fire radiative power)
+**Newest detection:** 2 days ago
+**Confidence:** 1 nominal
+**Satellite:** Suomi NPP (VIIRS)
+
+---
+
+## Detection Cluster 2
+
+**Detections:** 1 hotspot (0 day / 1 night)
+**Distance:** 52.1 km (32.4 mi) NNE
+**Center:** 38.3732, 24.0597
+**Peak intensity:** 1.5 MW (fire radiative power)
+**Newest detection:** 43.5 hours ago
+**Confidence:** 1 nominal
+**Satellite:** Suomi NPP (VIIRS)
+
+---
+
+## Detection Cluster 3
+
+**Detections:** 1 hotspot (0 day / 1 night)
+**Distance:** 95.6 km (59.4 mi) WSW
+**Center:** 37.6087, 22.7482
+**Peak intensity:** 1.2 MW (fire radiative power)
+**Newest detection:** 19.8 hours ago
+**Confidence:** 1 nominal
+**Satellite:** Suomi NPP (VIIRS)
+
+---
+
+## Detection Cluster 4
+
+**Detections:** 2 hotspots (2 day / 0 night)
+**Distance:** 127.4 km (79.2 mi) NNW
+**Center:** 38.9365, 22.9139
+**Peak intensity:** 6.4 MW (fire radiative power)
+**Newest detection:** 8.4 hours ago
+**Confidence:** 2 nominal
+**Satellite:** Suomi NPP (VIIRS)
+
+---
+
+## Detection Cluster 5
+
+**Detections:** 1 hotspot (0 day / 1 night)
+**Distance:** 152.7 km (94.9 mi) NNW
+**Center:** 39.1703, 22.8423
+**Peak intensity:** 1.1 MW (fire radiative power)
+**Newest detection:** 19.8 hours ago
+**Confidence:** 1 nominal
+**Satellite:** Suomi NPP (VIIRS)
+
+---
+
+
+*Note: 3 additional clusters found within radius (showing nearest 5 only — use detail="full" for more)*
+
+## Safety Assessment
+
+🟠 **HIGH ALERT** - Satellite fire detections within 25 km
+- Monitor fire conditions closely
+- Prepare for possible evacuation
+- Watch for smoke and changing conditions
+
+
+---
+*Data source: NASA FIRMS (Fire Information for Resource Management System)*
+*We acknowledge the use of data from NASA FIRMS (https://firms.modaps.eosdis.nasa.gov/), part of NASA's Earth Science Data and Information System (ESDIS).*
+*Satellite detections update with each polar overpass. Always consult official sources for evacuation orders and emergency information.*
+````
+
+</details>
+<!-- /capture:athens-hotspots -->
+
+**And the conditions themselves** (using `get_current_conditions` with `include_fire_weather`):
+
+<!-- answer-5 -->
+**Conditions right now are calm — Fosberg index 11 (Low)** — but that's an 11 PM reading on a still night (77°F, 5 mph wind), and the index is deliberately a *now* number, not a forecast.
+
+The line underneath it is the one that matters for next week: **vapour-pressure deficit 2.0 kPa (high drying power)** and **topsoil moisture 0.07 m³/m³ (very dry)**. The landscape is parched even though this particular hour is quiet. Add the afternoon heat — today topped out at 90°F — and a windy day would move that index fast.
+
+Two honesty notes the server makes itself, worth repeating:
+
+- **This index is computed here, not issued by an authority.** Greece has no equivalent of NOAA's published gridpoint indices, so the server derives Fosberg from temperature, humidity, and wind and labels it *"not an official fire-danger rating."* For an actual warning, heed the Hellenic Fire Service.
+- The underlying values are **model-interpolated, not a station observation** — the footer says so. If you want a real instrument reading, `source: "metar"` pulls the nearest airport.
+<!-- /answer-5 -->
+
+<!-- capture:athens-fire-weather -->
+<details>
+<summary>🔍 Tool call & raw server output — <code>get_current_conditions</code></summary>
+
+**Call:**
+
+```js
+get_current_conditions({
+  latitude: 37.9838,
+  longitude: 23.7275,
+  include_fire_weather: true
+})
+```
+
+**The server returned** (verbatim — this is exactly what the MCP client receives):
+
+````markdown
+# Current Weather Conditions
+
+**Time:** Aug 14, 2026, 11:15 PM
+
+**Conditions:** Clear sky
+**Temperature:** 77°F
+**Today's Range:** High 90°F / Low 75°F
+**Dewpoint:** 48°F
+**Humidity:** 36%
+**Wind:** 5 mph from 23°, gusting to 14 mph
+**Pressure:** 29.94 inHg
+**Cloud Cover:** 0%
+
+## Fire Weather
+
+**🟢 Fosberg Fire Weather Index:** 11 (Low)
+Computed from current temperature, humidity, and sustained wind. Higher values mean faster potential fire spread in fine fuels.
+
+**Dryness context:**
+- **Vapour-pressure deficit:** 2.0 kPa (high drying power)
+- **Topsoil moisture (top 1 cm):** 0.07 m³/m³ (very dry)
+
+*Derived by this server from Open-Meteo model data — not an official fire-danger rating. Heed warnings from your national fire authority.*
+
+---
+*Data source: Open-Meteo (Global) — model-interpolated values, not station observations*
+````
+
+</details>
+<!-- /capture:athens-fire-weather -->
+
+---
+
+**Features shown:** `get_wildfire_info` on both paths — NIFC named incidents in the US (containment, distance, safety tier) and NASA FIRMS satellite heat detections everywhere else (clustered hotspots, no names or containment, never an all-clear) · `get_current_conditions` with `include_fire_weather` on both paths — NOAA's published indices in the US, a server-computed Fosberg index with dryness context elsewhere, each labeled for what it is · `get_air_quality` on the US path — US AQI scale, pollutant breakdown (PM2.5 is the smoke signal), UV index, health recommendations.
 
 <!-- capture-stamp -->
 *Captured 2026-08-14 with weather-mcp v1.19.0 — raw output is live data and will differ when regenerated (`npm run examples`).*

--- a/scripts/capture-examples.mjs
+++ b/scripts/capture-examples.mjs
@@ -157,6 +157,27 @@ const EXAMPLES = [
         tool: 'get_air_quality',
         args: { latitude: 39.7392, longitude: -104.9903 },
       },
+      {
+        id: 'denver-fire-weather',
+        tool: 'get_current_conditions',
+        // US point: NOAA publishes its own fire-weather indices on the
+        // gridpoint API, so this path reports rather than computes.
+        args: { latitude: 39.7392, longitude: -104.9903, include_fire_weather: true },
+      },
+      {
+        id: 'athens-hotspots',
+        tool: 'get_wildfire_info',
+        // Outside the US there are no managed incidents to report — this
+        // routes to NASA FIRMS satellite heat detections instead.
+        args: { latitude: 37.9838, longitude: 23.7275, radius: 200, day_range: 3 },
+      },
+      {
+        id: 'athens-fire-weather',
+        tool: 'get_current_conditions',
+        // Non-US: no agency index exists, so the server computes a Fosberg
+        // index from temperature/humidity/wind and says so.
+        args: { latitude: 37.9838, longitude: 23.7275, include_fire_weather: true },
+      },
     ],
   },
   {


### PR DESCRIPTION
Closes the follow-up recorded in [`docs/plans/release-review-hardening-plan.md`](docs/plans/release-review-hardening-plan.md): neither v1.20.0 feature appeared in `examples/`. No scenario hit a FIRMS-routed location, and none passed `include_fire_weather` for a non-US point — so the folder would have shipped a release behind the code.

## Approach

`wildfire-awareness.md` becomes a two-sided story (**Denver & Athens**) rather than gaining a parallel file. That mirrors `river-and-flood.md`, which already uses Memphis + Manaus to make the data-mode contrast *the point* instead of a footnote — and the contrast is precisely what v1.20.0 added.

Three new captures, all regenerated live via `npm run examples -- wildfire`:

| Capture | Shows |
|---|---|
| `denver-fire-weather` | NOAA's **published** gridpoint indices — the US path, unchanged |
| `athens-hotspots` | **NASA FIRMS** satellite heat detections: 11 hotspots in 8 clusters, HIGH ALERT at 21.7 km |
| `athens-fire-weather` | The **computed** Fosberg index (11, Low) with dryness context |

The conversational layer leans on the distinction the release is about: named incidents vs. anonymous heat detections, an agency rating vs. a derived one. It says outright that a hotspot may be an industrial source or an agricultural burn, that the nearest Athens cluster is a 2-day-old single low-power detection rather than an advancing fire, and that an empty FIRMS result is still not an all-clear.

## Also in here

**Refreshed the existing Denver prose, which had drifted from its own regenerated capture** — AQI 51 → 59, PM2.5 8.8 → 7.3, UV 5 → 5.7, days active 45 → 46. The folder's stated premise is that the conversational answers were written from the output shown beneath them. Prose that contradicts a visible capture undermines that more than stale numbers do, so it seemed wrong to add new material next to it and leave it.

## Verification

`npm run build` 0 errors · 1,871 unit tests pass · `npm audit` 0 vulnerabilities · all capture markers paired, no placeholders left behind.

No source changes — docs, the capture manifest, and the examples README only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)