### PR TITLE
docs: Name the official npm package and how to verify it

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ Then just ask:
 
 📦 Listed in the [Official MCP Registry](https://registry.modelcontextprotocol.io/v0/servers?search=io.github.dgahagan/weather-mcp) as `io.github.dgahagan/weather-mcp`.
 
+✅ **The official package is [`@dangahagan/weather-mcp`](https://www.npmjs.com/package/@dangahagan/weather-mcp)**, published from this repository via npm [trusted publishing](https://docs.npmjs.com/trusted-publishers). Every release carries a signed provenance attestation tying the tarball to the exact commit and workflow that built it — verify any version without installing it:
+
+```bash
+npm view @dangahagan/weather-mcp@latest dist.attestations
+```
+
+Republished copies of this server exist under other npm scopes. They are MIT-licensed forks, which the license permits, but they are not maintained here and are usually many versions behind. This issue tracker covers `@dangahagan/weather-mcp` only — for anything installed from another scope, please report it to that package's publisher.
+
 ## Why this server?
 
 There are excellent commercial weather MCPs backed by paid APIs and full-time teams. If you need SLA-backed data, minute-level nowcasting, or premium global station coverage, they're worth a look — this project won't pretend otherwise.


### PR DESCRIPTION
## Why

Two third parties have republished this server under their own npm scopes. Both copy the description verbatim, and one keeps `repository`, `homepage`, and `bugs` pointing at **this** repo — so bug reports for *their* stale build land in *our* issue tracker.

| Package | Version | Published | Provenance |
|---|---|---|---|
| `@dangahagan/weather-mcp` (ours) | 1.23.0 | 2026-08-18 | **yes** |
| `@jablum/weather-mcp` | 1.7.8 | 2026-07-01 | no |
| `@iflow-mcp/dgahagan-weather-mcp` | 1.7.0 | 2026-04-08 | no |

Both are ~16 versions behind. The MIT licence permits the redistribution, so this is not a takedown request — it is a note so readers can tell which package is which, and so misrouted reports go to the right place.

## What this adds

Eight lines to `README.md`, directly under the MCP Registry line:

- Names `@dangahagan/weather-mcp` as the official package
- Shows the zero-install provenance check:
  ```
  npm view @dangahagan/weather-mcp@latest dist.attestations
  ```
- Scopes this issue tracker to the official package only

Provenance is the part republished copies structurally cannot fake — trusted publishing binds the attestation to this repo and `publish.yml`, so it is a real discriminator rather than an assertion.

## Notes

- Docs only. No code, no dependency, no behaviour change.
- Branched from `main` rather than the in-flight feature branch, so it can merge independently.
- Tone concedes the MIT point up front and names no one, so it stays accurate as further copies appear.